### PR TITLE
Revised Build process

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+    "presets": ["es2015"],
+    "plugins": [
+        "transform-object-rest-spread",
+        "syntax-object-rest-spread",
+        "transform-es3-property-literals",
+        "transform-es3-member-expression-literals"
+    ]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,32 +1,17 @@
 
 var gulp = require('gulp');
 var webpack = require('webpack');
-var gulpWebpack = require('gulp-webpack');
+var gulpWebpack = require('webpack-stream');
+var babel = require('gulp-babel');
+var sourcemaps = require('gulp-sourcemaps');
 
-gulp.task('build', ['webpack', 'webpack-min']);
+gulp.task('build', ['babel', 'webpack', 'webpack-min']);
 
 var FILE_NAME = 'sync-browser-mocks';
 var MODULE_NAME = 'syncBrowserMocks';
 
 var WEBPACK_CONFIG = {
-  module: {
-    loaders: [
-      {
-        test: /\.js$/,
-        exclude: /(node_modules|bower_components)/,
-        loader: 'babel',
-        query: {
-          presets: ['es2015'],
-          plugins: [
-            'transform-object-rest-spread',
-            'syntax-object-rest-spread',
-            'transform-es3-property-literals',
-            'transform-es3-member-expression-literals'
-          ]
-        }
-      }
-    ]
-  },
+  
   output: {
     filename: `${FILE_NAME}.js`,
     libraryTarget: 'umd',
@@ -53,14 +38,22 @@ var WEBPACK_CONFIG_MIN = Object.assign({}, WEBPACK_CONFIG, {
 });
 
 
-gulp.task('webpack', function() {
-  return gulp.src('src/index.js')
-      .pipe(gulpWebpack(WEBPACK_CONFIG))
-      .pipe(gulp.dest('dist'));
+gulp.task('webpack', ['babel'], function() {
+  return gulp.src('dist/index.js')
+      .pipe(gulpWebpack(WEBPACK_CONFIG, webpack))
+      .pipe(gulp.dest('dist/webpacks'));
 });
 
-gulp.task('webpack-min', function() {
-  return gulp.src('src/index.js')
-      .pipe(gulpWebpack(WEBPACK_CONFIG_MIN))
-      .pipe(gulp.dest('dist'));
+gulp.task('webpack-min', ['babel'], function() {
+  return gulp.src('dist/index.js')
+      .pipe(gulpWebpack(WEBPACK_CONFIG_MIN, webpack))
+      .pipe(gulp.dest('dist/webpacks'));
+});
+
+gulp.task('babel', function () {
+	return gulp.src('src/**/*.js')
+    .pipe(sourcemaps.init())
+		.pipe(babel())
+    .pipe(sourcemaps.write('.'))
+		.pipe(gulp.dest('dist'))
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var webpack = require('webpack');
 var gulpWebpack = require('webpack-stream');
 var babel = require('gulp-babel');
 var sourcemaps = require('gulp-sourcemaps');
+var UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
 gulp.task('build', ['babel', 'webpack', 'webpack-min']);
 
@@ -11,7 +12,21 @@ var FILE_NAME = 'sync-browser-mocks';
 var MODULE_NAME = 'syncBrowserMocks';
 
 var WEBPACK_CONFIG = {
-  
+
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: ["source-map-loader"],
+        enforce: "pre"
+      }
+    ]
+  },
+  plugins: [
+    new webpack.SourceMapDevToolPlugin({
+        filename: '[file].map'
+    })
+  ],
   output: {
     filename: `${FILE_NAME}.js`,
     libraryTarget: 'umd',
@@ -29,10 +44,14 @@ var WEBPACK_CONFIG_MIN = Object.assign({}, WEBPACK_CONFIG, {
     library: MODULE_NAME
   },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin({
-      test: /\.js$/,
-      exclude: /(node_modules|bower_components)/,
-      minimize: true
+    new webpack.SourceMapDevToolPlugin({
+        filename: '[file].map'
+    }),
+    new UglifyJSPlugin({
+        test: /\.js$/,
+        minimize: true,
+        compress: { warnings: false },
+        sourceMap: true
     })
   ]
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,6 +25,13 @@ var WEBPACK_CONFIG = {
   plugins: [
     new webpack.SourceMapDevToolPlugin({
         filename: '[file].map'
+    }),
+    new UglifyJSPlugin({
+        test: /\.js$/,
+        minimize: false,
+        compress: { warnings: false },
+        beautify: true,
+        sourceMap: true
     })
   ],
   output: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sync-browser-mocks",
   "version": "1.0.38",
   "description": "Synchronous browser mock shims.",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "eslint src/"
   },
@@ -37,8 +37,10 @@
     "babel-preset-es2015": "^6.6.0",
     "eslint": "^2",
     "gulp": "^3.9.1",
-    "gulp-webpack": "^1.5.0",
-    "webpack": "^1.13.0"
+    "gulp-babel": "^6.1.2",
+    "gulp-sourcemaps": "^2.4.1",
+    "webpack": "^2.2.1",
+    "webpack-stream": "^3.2.0"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "babel-core": "^6.7.7",
     "babel-eslint": "^6.0.4",
-    "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "^0.1.4",
     "babel-plugin-syntax-object-rest-spread": "^6.5.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.5.0",
@@ -39,6 +38,8 @@
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-sourcemaps": "^2.4.1",
+    "source-map-loader": "^0.2.0",
+    "uglifyjs-webpack-plugin": "^0.3.1",
     "webpack": "^2.2.1",
     "webpack-stream": "^3.2.0"
   },


### PR DESCRIPTION
1.  Upgrade to webpack 2
2.  Use gulp sourcemaps/babel instead of webpack
3.  Remove babel-loader
4.  Add gulp babel task
5.  Fix package.json entry point

All files are now built in the dist folder with source maps.  This will allow upstream modules to import without the src/.  Will make upstream module building quicker since they don't have to compile and create the sourcemaps.  Will allow tree shaking since you aren't including from the webpacked file, which is why your tests added the 25kb when switching from xcomponent/src.  webpack now builds to dist/webpacks.  May want to add a new root folder /webpacks or something.

I have post-robot done as well but this will have to go first, if agreed upon.