### PR TITLE
Allows mocking XHR request with an invalid status response

### DIFF
--- a/src/xhr.js
+++ b/src/xhr.js
@@ -10,7 +10,7 @@ export function $mockEndpoint(options) {
         options.uri = options.uri.replace(/\?/g, '\\?');
     }
 
-    this.status = options.status || 200;
+    this.status = options.status !== undefined ? options.status : 200;
 
     this.rawMethod = options.method.toString();
     this.rawUri = options.uri.toString();
@@ -221,11 +221,9 @@ SyncXMLHttpRequest.prototype = {
         this.response = this.responseText = JSON.stringify(response);
         this.readyState = 4;
 
-        if (this._eventHandlers.load) {
-            for (let handler of this._eventHandlers.load) {
-                handler.call(this);
-            }
-        }
+        for (let handler of Object.values(this._eventHandlers).flat()) {
+            handler.call(this);
+        };
 
         let callback = this.onreadystatechange || this.onload;
 


### PR DESCRIPTION
### Description
The PR makes a proposal to allow passing invalid status code/values on XHR mocking calls, also calls all the registered events listeners to the mocked instance.

### Why are we making these changes?
To be able to enable unhappy test cases after mocking an endpoint. Now any kind of invalid status will be replaced with a 200 status code. There can be cases where we need to mock an endpoint setting the status code to something invalid like `null`.

### Caveats
This is a proposed solution where the status code will keep values such as: `[null, 0, false]` and only will take the default one when is `undefined`. Can be a major change if some repos rely on `status = null` and are expecting a 200 status code in the response